### PR TITLE
fix🐛:  Ecarts cannot be displayed

### DIFF
--- a/src/markdown-it-vue-light.vue
+++ b/src/markdown-it-vue-light.vue
@@ -26,7 +26,7 @@ import MarkdownItFontAwsome from './markdown-it-font-awsome'
 import 'github-markdown-css'
 import 'markdown-it-latex/dist/index.css'
 
-import echarts from 'echarts/dist/echarts.simple.min'
+import * as echarts from 'echarts/dist/echarts.simple.min'
 import flowchart from 'flowchart.js'
 
 const DEFAULT_OPTIONS_LINK_ATTRIBUTES = {

--- a/src/markdown-it-vue.vue
+++ b/src/markdown-it-vue.vue
@@ -40,7 +40,7 @@ import MarkdownItImage from './markdown-it-image'
 import 'github-markdown-css'
 import 'markdown-it-latex/dist/index.css'
 
-import echarts from 'echarts/dist/echarts.simple.min'
+import * as echarts from 'echarts/dist/echarts.simple.min'
 import mermaid from 'mermaid'
 import flowchart from 'flowchart.js'
 import ImageViewer from './markdown-it-image/image-viewer.vue'


### PR DESCRIPTION
https://github.com/ravenq/markdown-it-vue/issues/63